### PR TITLE
Cleanup new_snippet.js

### DIFF
--- a/app/views/dialogs/new_snippet.js
+++ b/app/views/dialogs/new_snippet.js
@@ -44,7 +44,6 @@ class NewSnippet extends DialogBase {
 
     console.log(`${data.snippet_name} saved to ${snippetsPath}`);
 
-		// append to json file	
     fs.writeFileSync(snippetsPath, JSON.stringify(customSnippets, null, 2));
 
     this.close();

--- a/app/views/dialogs/new_snippet.js
+++ b/app/views/dialogs/new_snippet.js
@@ -6,7 +6,7 @@ class NewSnippet extends DialogBase {
   code: string
   */
 
-  constructor(code) {
+  constructor (code) {
     super(null, {
       dialogClass: 'new-snippet-dialog',
       title: 'New Snippet',
@@ -24,7 +24,7 @@ class NewSnippet extends DialogBase {
     this.bindFormSubmitting();
   }
 
-  onSubmit(data) {
+  onSubmit (data) {
     if (!data.snippet_name) {
       return $u.alert('A Snippet name is required!');
     }

--- a/app/views/dialogs/new_snippet.js
+++ b/app/views/dialogs/new_snippet.js
@@ -1,52 +1,52 @@
-var fs = require('fs');
-var path = require('path');
-//var electron = require('electron');
+const fs = require('fs');
+const path = require('path');
 
 class NewSnippet extends DialogBase {
   /*::
   code: string
   */
 
-  constructor (code) {
+  constructor(code) {
     super(null, {
-      dialogClass: "new-snippet-dialog",
-      title: "New Snippet",
+      dialogClass: 'new-snippet-dialog',
+      title: 'New Snippet',
       code: code
     });
+
     this.showWindow();
   }
 
-  showWindow () {
-    var nodes = App.renderView('dialogs/new_snippet', {code: this.code});
+  showWindow() {
+    const nodes = App.renderView('dialogs/new_snippet', { code: this.code });
     this.content = this.renderWindow(this.title, nodes);
     window.hljs.highlightBlock(this.content.find('code')[0]);
 
     this.bindFormSubmitting();
   }
 
-  onSubmit (data) {
-    // Apped to json file
-    if (data.snippet_name) {
-      var snippetsPath = path.join(electron.remote.app.getPath('userData'), 'custom_snippets.json');
-
-      var customSnippets = {};
-      if (fs.existsSync(snippetsPath)) {
-        customSnippets = JSON.parse(fs.readFileSync(snippetsPath))
-      }
-
-      customSnippets[data.snippet_name] = {
-        description: data.description,
-        sql: this.code
-      };
-
-      console.log('saving snippet to ', snippetsPath);
-      console.log('data', JSON.stringify(customSnippets, null, 2));
-      fs.writeFileSync(snippetsPath, JSON.stringify(customSnippets, null, 2));
-      this.close();
+  onSubmit(data) {
+    if (!data.snippet_name) {
+      return $u.alert('A Snippet name is required!');
     }
-    else {
-      $u.alert('A Snippet name is required!');
+
+    const snippetsPath = path.join(electron.remote.app.getPath('userData'), 'custom_snippets.json');
+
+    let customSnippets = {};
+
+    if (fs.existsSync(snippetsPath)) {
+      customSnippets = JSON.parse(fs.readFileSync(snippetsPath))
     }
+
+    customSnippets[data.snippet_name] = {
+      description: data.description,
+      sql: this.code
+    };
+
+    console.log(`${data.snippet_name} saved to ${snippetsPath}`);
+
+    fs.writeFileSync(snippetsPath, JSON.stringify(customSnippets, null, 2));
+
+    this.close();
   }
 }
 

--- a/app/views/dialogs/new_snippet.js
+++ b/app/views/dialogs/new_snippet.js
@@ -44,6 +44,7 @@ class NewSnippet extends DialogBase {
 
     console.log(`${data.snippet_name} saved to ${snippetsPath}`);
 
+		// append to json file	
     fs.writeFileSync(snippetsPath, JSON.stringify(customSnippets, null, 2));
 
     this.close();


### PR DESCRIPTION
- convert var -> let/const where relevant 
- handle unnamed snippet error first vs. in else branch
- make quote-style uniform 
- don't log users entire `custom_snippets.json` file on submit, instead just the name of the snippet saved and path 