### PR TITLE
Fix for issue 118

### DIFF
--- a/app.js
+++ b/app.js
@@ -76,7 +76,7 @@ interface App {
 */
 
 global.App = {
-  root: remote.app.MainFilename.replace(/\/(index\.html|main\.js)/, ''),
+  root: remote.app.getAppPath(),
   // used for running binaries inside asar package
   vendorPath: remote.app.MainFilename.includes('app.asar') ?
     path.join(remote.app.MainFilename, `../../../vendor/${process.platform}`) :


### PR DESCRIPTION
Fixes issue #118 

Hey @Paxa 

it seems that this line from app.js is not working on Windows:

`root: remote.app.MainFilename.replace(/\/(index\.html|main\.js)/, ''),`

here's the error from console when I try to open "See History", you can see that `/index.html` is not removed :

```
Error: ERR_FILE_NOT_FOUND (-6) loading 'file:///C:/Users/[user]/AppData/Local/Programs/Postbird/resources/app.asar/index.html/views/history_window.html'
```
Same when I open snippets.
```
Error: ERR_FILE_NOT_FOUND (-6) loading 'file:///C:/Users/[user]/AppData/Local/Programs/Postbird/resources/app.asar/index.html/views/snippets_window.html'
```

So I changed the way we get the root of the app, and now it works on my Windows machine

`root: remote.app.getAppPath()`

you can see getAppPath() documentation here: 

https://github.com/electron/electron/blob/master/docs/api/app.md#appgetapppath
