### PR TITLE
Debounced tables filtering

### DIFF
--- a/app/utils.js
+++ b/app/utils.js
@@ -400,3 +400,13 @@ $u.textareaAutoSize = function (element) {
   element.style.height = 'auto';
   element.style.height = element.scrollHeight + 'px';
 };
+
+$u.debounce = (func, delay) => {
+  let inDebounce;
+  return function () {
+    const context = this;
+    const args = arguments;
+    clearTimeout(inDebounce);
+    inDebounce = setTimeout(() => func.apply(context, args), delay);
+  };
+};

--- a/app/views/db_screen_view.js
+++ b/app/views/db_screen_view.js
@@ -51,7 +51,8 @@ class DbScreenView {
     this.sidebar.find('a.addTable').bind('click', this.newTableDialog.bind(this));
     this.sidebar.find('a.reloadStructure').bind('click', this.reloadStructure.bind(this));
 
-    this.sidebar.find('input.filter-tables').bind('keyup', this.filterTables.bind(this));
+    this.sidebar.find('input.filter-tables')
+      .bind('keyup', $u.debounce(this.filterTables, 500).bind(this));
     this.sidebar.find('span.clear-filter').bind('click', () => {
       this.clearTablesFilter();
     })


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9221865/113443148-aa63ca00-93f1-11eb-9e0d-ecf87baa9ebe.png)

The issue is related to the `Filter Tables` input and it's more obvious when you are working with a larger number of database schemas. 
The input is kind of blocked after each `keyup` event since `filterTables` function is called multiple times. 
As a solution debounce utility function is introduced which can be reused.